### PR TITLE
feat(review): add 'reviewed' status and AJAX UX improvements

### DIFF
--- a/app/Models/Submission.php
+++ b/app/Models/Submission.php
@@ -49,7 +49,7 @@ class Submission extends Model
 
     public function isCompleted(): bool
     {
-        return $this->status === 'completed' || $this->status === 'submitted';
+        return in_array($this->status, ['completed', 'submitted', 'reviewed'], true);
     }
 
     public function isInProgress(): bool

--- a/app/Models/SubmissionAnswer.php
+++ b/app/Models/SubmissionAnswer.php
@@ -44,17 +44,36 @@ class SubmissionAnswer extends Model
 
     public function hasVideo(): bool
     {
-        return !empty($this->video_path) && Storage::exists($this->video_path);
+        return !empty($this->video_path)
+            && Storage::disk('public')->exists($this->video_path);
     }
 
     public function getVideoUrl(): ?string
     {
-        return $this->hasVideo() ? Storage::url($this->video_path) : null;
+        if (!$this->hasVideo()) {
+            return null;
+        }
+        // Public disk is linked to /storage via storage:link
+        return asset('storage/'.ltrim($this->video_path, '/'));
     }
 
     public function getVideoSize(): ?int
     {
-        return $this->hasVideo() ? Storage::size($this->video_path) : null;
+        return $this->hasVideo()
+            ? Storage::disk('public')->size($this->video_path)
+            : null;
+    }
+
+    public function getVideoMimeType(): string
+    {
+        $path = strtolower((string) $this->video_path);
+        if (str_ends_with($path, '.mp4')) {
+            return 'video/mp4';
+        }
+        if (str_ends_with($path, '.webm')) {
+            return 'video/webm';
+        }
+        return 'video/webm';
     }
 
     public function isCompleted(): bool

--- a/database/migrations/2025_09_13_021500_alter_status_enum_add_reviewed_to_submissions_table.php
+++ b/database/migrations/2025_09_13_021500_alter_status_enum_add_reviewed_to_submissions_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        // Add 'reviewed' to the ENUM of submissions.status
+        DB::statement(
+            "ALTER TABLE `submissions` MODIFY `status` " .
+            "ENUM('in_progress','completed','submitted','reviewed') " .
+            "NOT NULL DEFAULT 'in_progress'"
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        // Convert any 'reviewed' back to 'completed' before shrinking the enum
+        DB::table('submissions')
+            ->where('status', 'reviewed')
+            ->update(['status' => 'completed']);
+
+        DB::statement(
+            "ALTER TABLE `submissions` MODIFY `status` " .
+            "ENUM('in_progress','completed','submitted') " .
+            "NOT NULL DEFAULT 'in_progress'"
+        );
+    }
+};

--- a/resources/views/interviews/start.blade.php
+++ b/resources/views/interviews/start.blade.php
@@ -233,7 +233,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         
         checkReadiness();
     } catch (error) {
-        console.log('Auto-check failed, manual check required');
+        console.warn('Auto-check failed:', error?.name, error?.message);
+        // Mantém o manual check, mas dá uma mensagem útil se for permissão negada
+        if (error && (error.name === 'NotAllowedError' || error.name === 'SecurityError')) {
+            alert('O navegador bloqueou o acesso à câmera/microfone. Clique no ícone de cadeado na barra de endereços e permita o acesso.');
+        }
     }
 });
 
@@ -243,6 +247,16 @@ window.addEventListener('beforeunload', () => {
         testStream.getTracks().forEach(track => track.stop());
     }
 });
+
+// Para evitar manter a câmera aberta ao iniciar a entrevista
+const startForm = document.querySelector('form[action="{{ route('submissions.start', $interview) }}"]');
+if (startForm) {
+    startForm.addEventListener('submit', () => {
+        if (testStream) {
+            try { testStream.getTracks().forEach(t => t.stop()); } catch (e) {}
+        }
+    });
+}
 </script>
 
 <style>

--- a/resources/views/submissions/review.blade.php
+++ b/resources/views/submissions/review.blade.php
@@ -13,7 +13,7 @@
                         </div>
                     </div>
                     <div class="flex items-center space-x-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{ $submission->status === 'completed' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800' }}">
+                        <span id="submission-status-badge" class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{ in_array($submission->status, ['completed','submitted','reviewed']) ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800' }}">
                             {{ ucfirst($submission->status) }}
                         </span>
                         <div class="w-24 bg-gray-200 rounded-full h-5">
@@ -74,12 +74,14 @@
                                 @if($answer->hasVideo())
                                     <div class="video-container mb-6">
                                         <video controls class="w-full rounded-lg" style="max-height: 400px;">
-                                            <source src="{{ $answer->getVideoUrl() }}" type="video/mp4">
+                                            <source src="{{ $answer->getVideoUrl() }}" type="{{ $answer->getVideoMimeType() }}">
                                             Your browser does not support the video tag.
                                         </video>
                                         <div class="mt-2 text-sm text-gray-600">
-                                            Duration: {{ $answer->getFormattedDuration() }} | 
-                                            Size: {{ $answer->getVideoSize() }}
+                                            Duration: {{ $answer->getFormattedDuration() }}
+                                            @if($answer->getVideoSize())
+                                                | Size: {{ number_format($answer->getVideoSize() / 1024 / 1024, 2) }} MB
+                                            @endif
                                         </div>
                                     </div>
                                 @endif
@@ -122,7 +124,10 @@
                                         </div>
                                         
                                         <div class="mt-6">
-                                            <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Save Review</button>
+                                            <button type="submit" class="review-save-btn bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-flex items-center gap-2">
+                                                <svg class="btn-spinner hidden animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>
+                                                <span class="btn-text">Save Review</span>
+                                            </button>
                                         </div>
                                     </form>
                                 </div>
@@ -148,55 +153,148 @@
                 <h5 class="text-xl font-bold text-gray-900">Overall Review</h5>
             </div>
             <div class="px-6 py-6">
-                    <form action="{{ route('submissions.save-overall-review') }}" method="POST">
+                    <form id="overall-review-form" action="{{ route('submissions.save-overall-review') }}" method="POST" class="space-y-6">
                         @csrf
                         <input type="hidden" name="submission_id" value="{{ $submission->id }}">
-                        
-                        <div class="row">
-                            <div class="col-md-6">
-                                <div class="mb-3">
-                                    <label class="form-label">Overall Score (1-100)</label>
-                                    <input type="number" name="overall_score" class="form-control" 
-                                           min="1" max="100" 
-                                           value="{{ old('overall_score', $submission->overall_score ?? '') }}"
-                                           placeholder="Enter overall score">
-                                </div>
+
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-2">Overall Score (1-100)</label>
+                                <input type="number" name="overall_score" min="1" max="100"
+                                       value="{{ old('overall_score', $submission->overall_score ?? '') }}"
+                                       placeholder="Enter overall score"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent">
                             </div>
-                            <div class="col-md-6">
-                                <div class="mb-3">
-                                    <label class="form-label">Recommendation</label>
-                                    <select name="recommendation" class="form-select">
-                                        <option value="">Select recommendation...</option>
-                                        <option value="strongly_recommend" {{ old('recommendation', $submission->recommendation ?? '') == 'strongly_recommend' ? 'selected' : '' }}>Strongly Recommend</option>
-                                        <option value="recommend" {{ old('recommendation', $submission->recommendation ?? '') == 'recommend' ? 'selected' : '' }}>Recommend</option>
-                                        <option value="neutral" {{ old('recommendation', $submission->recommendation ?? '') == 'neutral' ? 'selected' : '' }}>Neutral</option>
-                                        <option value="not_recommend" {{ old('recommendation', $submission->recommendation ?? '') == 'not_recommend' ? 'selected' : '' }}>Not Recommend</option>
-                                        <option value="strongly_not_recommend" {{ old('recommendation', $submission->recommendation ?? '') == 'strongly_not_recommend' ? 'selected' : '' }}>Strongly Not Recommend</option>
-                                    </select>
-                                </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-2">Recommendation</label>
+                                <select name="recommendation"
+                                        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent">
+                                    <option value="">Select recommendation...</option>
+                                    <option value="strongly_recommend" {{ old('recommendation', $submission->recommendation ?? '') == 'strongly_recommend' ? 'selected' : '' }}>Strongly Recommend</option>
+                                    <option value="recommend" {{ old('recommendation', $submission->recommendation ?? '') == 'recommend' ? 'selected' : '' }}>Recommend</option>
+                                    <option value="neutral" {{ old('recommendation', $submission->recommendation ?? '') == 'neutral' ? 'selected' : '' }}>Neutral</option>
+                                    <option value="not_recommend" {{ old('recommendation', $submission->recommendation ?? '') == 'not_recommend' ? 'selected' : '' }}>Not Recommend</option>
+                                    <option value="strongly_not_recommend" {{ old('recommendation', $submission->recommendation ?? '') == 'strongly_not_recommend' ? 'selected' : '' }}>Strongly Not Recommend</option>
+                                </select>
                             </div>
                         </div>
-                        
-                        <div class="mb-3">
-                            <label class="form-label">Overall Comments</label>
-                            <textarea name="overall_comments" class="form-control" rows="4" 
-                                      placeholder="Provide overall feedback for this candidate...">{{ old('overall_comments', $submission->overall_comments ?? '') }}</textarea>
+
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-2">Overall Comments</label>
+                            <textarea name="overall_comments" rows="4"
+                                      placeholder="Provide overall feedback for this candidate..."
+                                      class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent">{{ old('overall_comments', $submission->overall_comments ?? '') }}</textarea>
                         </div>
-                        
-                        <div class="d-flex justify-content-between">
-                            <a href="{{ route('submissions.index') }}" class="btn btn-secondary">
-                                <i class="bi bi-arrow-left"></i> Back to Submissions
-                            </a>
-                            <button type="submit" class="btn btn-success">
-                                <i class="bi bi-check-circle"></i> Save Overall Review
+
+                        <div class="flex items-center justify-between">
+                            <a href="{{ route('submissions.index') }}" class="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold">Back to Submissions</a>
+                            <button type="submit" id="overall-save-btn" class="px-4 py-2 rounded bg-green-600 hover:bg-green-700 text-white font-semibold inline-flex items-center gap-2">
+                                <svg class="btn-spinner hidden animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path></svg>
+                                <span class="btn-text">Save Overall Review</span>
                             </button>
                         </div>
+                        <div id="overall-review-feedback" class="hidden mt-3 text-sm"></div>
                     </form>
                 </div>
             </div>
         </div>
     </div>
 </div>
+
+<script>
+// AJAX para cada review de resposta
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[class^="review-form-"]').forEach(form => {
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const fd = new FormData(form);
+            const btn = form.querySelector('.review-save-btn');
+            const spinner = btn?.querySelector('.btn-spinner');
+            const btnText = btn?.querySelector('.btn-text');
+            try {
+                if (btn) {
+                    btn.disabled = true;
+                    if (spinner) spinner.classList.remove('hidden');
+                    if (btnText) btnText.textContent = 'Salvando...';
+                }
+                const res = await fetch(form.getAttribute('action'), {
+                    method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                        'Accept': 'application/json',
+                    },
+                    body: fd,
+                });
+                const data = await res.json();
+                const box = document.createElement('div');
+                box.className = 'mt-3 text-sm rounded px-3 py-2 ' + (data.success ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700');
+                box.textContent = data.message || (data.success ? 'Saved!' : 'Failed to save');
+                form.appendChild(box);
+                setTimeout(() => box.remove(), 3000);
+            } catch (err) {
+                console.error('Save review error:', err);
+            } finally {
+                if (btn) {
+                    btn.disabled = false;
+                    if (spinner) spinner.classList.add('hidden');
+                    if (btnText) btnText.textContent = 'Save Review';
+                }
+            }
+        });
+    });
+
+    // AJAX para Overall Review
+    const overallForm = document.getElementById('overall-review-form');
+    const feedback = document.getElementById('overall-review-feedback');
+    overallForm?.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const fd = new FormData(overallForm);
+        const btn = document.getElementById('overall-save-btn');
+        const spinner = btn?.querySelector('.btn-spinner');
+        const btnText = btn?.querySelector('.btn-text');
+        try {
+            if (btn) {
+                btn.disabled = true;
+                if (spinner) spinner.classList.remove('hidden');
+                if (btnText) btnText.textContent = 'Salvando...';
+            }
+            const res = await fetch(overallForm.getAttribute('action'), {
+                method: 'POST',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                    'Accept': 'application/json',
+                },
+                body: fd,
+            });
+            const data = await res.json();
+            feedback.className = 'mt-3 text-sm rounded px-3 py-2 ' + (data.success ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700');
+            feedback.textContent = data.message || (data.success ? 'Saved!' : 'Failed to save');
+            feedback.classList.remove('hidden');
+            setTimeout(() => feedback.classList.add('hidden'), 3000);
+
+            // If status returned as reviewed, update badge UI
+            if (data?.submission?.status === 'reviewed') {
+                const badge = document.getElementById('submission-status-badge');
+                if (badge) {
+                    badge.textContent = 'Reviewed';
+                    badge.classList.remove('bg-yellow-100','text-yellow-800');
+                    badge.classList.add('bg-green-100','text-green-800');
+                }
+            }
+        } catch (err) {
+            console.error('Save overall review error:', err);
+        } finally {
+            if (btn) {
+                btn.disabled = false;
+                if (spinner) spinner.classList.add('hidden');
+                if (btnText) btnText.textContent = 'Save Overall Review';
+            }
+        }
+    });
+});
+</script>
 
 <style>
 /* TailwindCSS handles most styling, minimal custom CSS needed */

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,8 @@ Route::middleware('auth')->group(function () {
         ->name('submissions.start');
     Route::get('submissions/{submission}/interview', [SubmissionController::class, 'interview'])
         ->name('submissions.interview');
+    Route::post('submissions/{submission}/submit', [SubmissionController::class, 'submit'])
+        ->name('submissions.submit');
     Route::get('submissions/{submission}/review', [SubmissionController::class, 'review'])
         ->name('submissions.review')
         ->middleware('can:manage-interviews');


### PR DESCRIPTION
This PR fixes a DB enum mismatch and improves reviewer UX.

What changed
- DB: Add 'reviewed' to submissions.status enum via migration (includes safe down that maps 'reviewed' -> 'completed').
- Model: Submission::isCompleted now counts 'reviewed' as final state.
- UI (review page):
  - Add loading spinner and disable Save buttons during AJAX submits (per-answer and overall).
  - Update status badge to treat 'reviewed' as final (green) and update live after saving overall review.
  - Minor copy to pt-BR for loading state ("Salvando...").

Why
- Fixes SQLSTATE[01000] Warning 1265 (Data truncated for column 'status') when setting status='reviewed'.
- Gives clear feedback during AJAX saves, avoiding double submissions on reload.

How to test
1. Run migrations inside the container.
2. Open a submission review page.
3. Save per-answer review and overall review. Buttons should show spinner, disable while saving, and re-enable on completion.
4. After saving overall review, the badge should update to "Reviewed" with green styling.

Notes
- Migration alters the enum in place; compatible with MySQL.
- If needed, we can add toasts or progress bars later.