### PR TITLE
Add core unit tests, authorization tests, and update README PHPUnit results

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,120 @@ docker-compose exec laravel.test php artisan migrate
 docker-compose exec laravel.test php artisan db:seed
 ```
 
+## 🧪 PHPUnit
+
+Resultado recente da suíte de testes (ambiente local dentro do container):
+
+```
+# php artisan test
+
+   PASS  Tests\Unit\ExampleTest
+  ✓ that true is true                                                                                                                                     0.17s  
+
+   PASS  Tests\Unit\SubmissionAnswerModelTest
+  ✓ get video mime type from extension                                                                                                                   10.08s  
+
+   PASS  Tests\Unit\SubmissionModelTest
+  ✓ is completed true for completed submitted reviewed                                                                                                    0.19s  
+  ✓ is completed false for in progress and other                                                                                                          0.19s  
+  ✓ get progress percentage calculates correctly                                                                                                          1.20s  
+  ✓ get progress percentage zero when no questions                                                                                                        0.25s  
+
+   PASS  Tests\Feature\Auth\AuthenticationTest
+  ✓ login screen can be rendered                                                                                                                          2.58s  
+  ✓ users can authenticate using the login screen                                                                                                         0.84s  
+  ✓ users can not authenticate with invalid password                                                                                                      0.62s  
+  ✓ users can logout                                                                                                                                      0.34s  
+
+   PASS  Tests\Feature\Auth\EmailVerificationTest
+  ✓ email verification screen can be rendered                                                                                                             0.37s  
+  ✓ email can be verified                                                                                                                                 0.37s  
+  ✓ email is not verified with invalid hash                                                                                                               0.37s  
+
+   PASS  Tests\Feature\Auth\PasswordConfirmationTest
+  ✓ confirm password screen can be rendered                                                                                                               0.47s  
+  ✓ password can be confirmed                                                                                                                             0.30s  
+  ✓ password is not confirmed with invalid password                                                                                                       0.57s  
+
+   PASS  Tests\Feature\Auth\PasswordResetTest
+  ✓ reset password link screen can be rendered                                                                                                            0.42s  
+  ✓ reset password link can be requested                                                                                                                  1.12s  
+  ✓ reset password screen can be rendered                                                                                                                 0.72s  
+  ✓ password can be reset with valid token                                                                                                                0.63s  
+
+   PASS  Tests\Feature\Auth\PasswordUpdateTest
+  ✓ password can be updated                                                                                                                               0.21s  
+  ✓ correct password must be provided to update password                                                                                                  0.29s  
+
+   PASS  Tests\Feature\Auth\RegistrationTest
+  ✓ registration screen can be rendered                                                                                                                   0.52s  
+  ✓ new users can register                                                                                                                                0.27s  
+
+   PASS  Tests\Feature\AuthorizationTest
+  ✓ guest is redirected to login                                                                                                                          0.26s  
+  ✓ candidate cannot access manage routes                                                                                                                 0.40s  
+  ✓ reviewer can access manage routes                                                                                                                     0.76s  
+  ✓ admin can access manage routes                                                                                                                        0.62s  
+  ✓ candidate can start and submit but not review                                                                                                         1.24s  
+
+   PASS  Tests\Feature\ExampleTest
+  ✓ the application returns a successful response                                                                                                         0.40s  
+
+   PASS  Tests\Feature\InterviewCrudTest
+  ✓ reviewer can create interview with questions                                                                                                          0.29s  
+
+   PASS  Tests\Feature\ProfileTest
+  ✓ profile page is displayed                                                                                                                             1.26s  
+  ✓ profile information can be updated                                                                                                                    0.48s  
+  ✓ email verification status is unchanged when the email address is unchanged                                                                            0.37s  
+  ✓ user can delete their account                                                                                                                         0.32s  
+  ✓ correct password must be provided to delete account                                                                                                   0.40s  
+
+   PASS  Tests\Feature\SubmissionAndReviewTest
+  ✓ candidate can upload video answer and submit                                                                                                          1.19s  
+  ✓ reviewer can save answer review and overall review                                                                                                    0.44s  
+
+  Tests:    38 passed (104 assertions)
+  Duration: 34.58s
+```
+
+### Como rodar os testes
+
+Execute os testes sempre dentro do container (Windows sem WSL):
+
+```bash
+docker-compose exec laravel.test php artisan test
+```
+
+Rodar apenas os de Feature ou Unit:
+
+```bash
+docker-compose exec laravel.test php artisan test --testsuite=Feature
+docker-compose exec laravel.test php artisan test --testsuite=Unit
+```
+
+Executar um arquivo de teste específico:
+
+```bash
+docker-compose exec laravel.test php artisan test tests/Feature/SubmissionAndReviewTest.php
+```
+
+### Notas de ambiente de teste
+
+- Os testes usam SQLite em memória para rapidez (config em `phpunit.xml`).
+- As migrations que dependem de MySQL (ex.: alteração de ENUM) são guardadas para não rodarem no SQLite durante os testes.
+- Uploads de vídeo nos testes usam `Storage::fake('public')` para não escrever no disco real.
+
+### Badge de CI (opcional)
+
+Se configurar GitHub Actions, você pode adicionar um badge no topo do README:
+
+```md
+![tests](https://github.com/marcellopato/horizon/actions/workflows/tests.yml/badge.svg)
+```
+
 ### Development
+
 ```bash
 # Start development server with HMR
 docker-compose exec laravel.test npm run dev
@@ -131,7 +244,7 @@ docker-compose exec laravel.test php artisan test
 
 ## 📁 Project Structure
 
-```
+```text
 horizon/
 ├── app/
 │   ├── Http/
@@ -151,6 +264,7 @@ horizon/
 ## 🔄 Git Workflow
 
 The project follows a feature-branch workflow:
+
 - `main` - Production-ready code
 - `feature/*` - Feature development branches
 - All changes go through Pull Requests

--- a/database/migrations/2025_09_13_021500_alter_status_enum_add_reviewed_to_submissions_table.php
+++ b/database/migrations/2025_09_13_021500_alter_status_enum_add_reviewed_to_submissions_table.php
@@ -12,7 +12,12 @@ return new class extends Migration
      */
     public function up(): void
     {
-        // Add 'reviewed' to the ENUM of submissions.status
+            // Run only on MySQL/MariaDB (SQLite tests skip).
+        $driver = DB::getDriverName();
+        if (!in_array($driver, ['mysql', 'mariadb'], true)) {
+            return;
+        }
+
         DB::statement(
             "ALTER TABLE `submissions` MODIFY `status` " .
             "ENUM('in_progress','completed','submitted','reviewed') " .
@@ -27,6 +32,11 @@ return new class extends Migration
      */
     public function down(): void
     {
+        $driver = DB::getDriverName();
+        if (!in_array($driver, ['mysql', 'mariadb'], true)) {
+            return;
+        }
+
         // Convert any 'reviewed' back to 'completed' before shrinking the enum
         DB::table('submissions')
             ->where('status', 'reviewed')

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,7 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_DATABASE" value="testing"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    /**
+     * Create the application instance for testing.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    public function createApplication()
+    {
+            include __DIR__.'/../bootstrap/app.php';
+            /**
+             * The Laravel application instance.
+             *
+             * @var \Illuminate\Foundation\Application $app
+             */
+            $app = app();
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -18,12 +18,16 @@ class RegistrationTest extends TestCase
 
     public function test_new_users_can_register(): void
     {
-        $response = $this->post('/register', [
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-            'password' => 'password',
-            'password_confirmation' => 'password',
-        ]);
+        $response = $this->post(
+            '/register',
+            [
+                'name' => 'Test User',
+                'email' => 'test@example.com',
+                'role' => 'candidate',
+                'password' => 'password',
+                'password_confirmation' => 'password',
+            ]
+        );
 
         $this->assertAuthenticated();
         $response->assertRedirect(route('dashboard', absolute: false));

--- a/tests/Feature/AuthorizationTest.php
+++ b/tests/Feature/AuthorizationTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Interview;
+use App\Models\User;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+/**
+ * Feature tests for role-based authorization on routes.
+ *
+ * @category Tests
+ * @package  Feature
+ * @author   Horizon Team <dev@horizon.local>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://github.com/marcellopato/horizon
+ */
+class AuthorizationTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     * Helper to create user with a specific role.
+     *
+     * @param string $role Role name
+     *
+     * @return User
+     */
+    protected function createUser(string $role): User
+    {
+        return User::factory()->create(
+            [
+                'role' => $role,
+            ]
+        );
+    }
+
+    /**
+     * Guests should be redirected to login on protected pages.
+     *
+     * @return void
+     */
+    public function testGuestIsRedirectedToLogin(): void
+    {
+        $response = $this->get('/interviews');
+        $response->assertRedirect('/login');
+    }
+
+    /**
+     * Candidate must receive 403 on manage interview routes.
+     *
+     * @return void
+     */
+    public function testCandidateCannotAccessManageRoutes(): void
+    {
+        $candidate = $this->createUser('candidate');
+        $this->actingAs($candidate);
+
+        // create
+        $this->get('/interviews/create')->assertStatus(403);
+        // store
+        $this->post(
+            '/interviews',
+            [
+                'title' => 'X',
+                'description' => 'Y',
+                'time_limit' => 10,
+            ]
+        )->assertStatus(403);
+    }
+
+    /**
+     * Reviewer should access manage routes successfully.
+     *
+     * @return void
+     */
+    public function testReviewerCanAccessManageRoutes(): void
+    {
+        $reviewer = $this->createUser('reviewer');
+        $this->actingAs($reviewer);
+
+        $this->get('/interviews/create')->assertOk();
+
+        $resp = $this->post(
+            '/interviews',
+            [
+                'title' => 'R Test',
+                'description' => 'Reviewer can create',
+                'time_limit' => 15,
+                'questions' => [
+                    ['question' => 'Why us?', 'time_limit' => 60],
+                ],
+            ]
+        );
+        $resp->assertRedirect();
+    }
+
+    /**
+     * Admin should access manage routes successfully.
+     *
+     * @return void
+     */
+    public function testAdminCanAccessManageRoutes(): void
+    {
+        $admin = $this->createUser('admin');
+        $this->actingAs($admin);
+
+        $this->get('/interviews/create')->assertOk();
+    }
+
+    /**
+     * Candidate can browse and start, but not access review area.
+     *
+     * @return void
+     */
+    public function testCandidateCanStartAndSubmitButNotReview(): void
+    {
+        $reviewer = $this->createUser('reviewer');
+        $this->actingAs($reviewer);
+
+        // reviewer creates interview
+        $this->post(
+            '/interviews',
+            [
+                'title' => 'Interview',
+                'description' => 'Desc',
+                'time_limit' => 10,
+                'questions' => [
+                    ['question' => 'Q1', 'time_limit' => 60],
+                ],
+            ]
+        )->assertRedirect();
+
+        /**
+         * Interview instance created by reviewer
+         *
+         * @var Interview $interview
+         */
+        $interview = Interview::latest('id')->first();
+
+        // switch to candidate
+        $candidate = $this->createUser('candidate');
+        $this->actingAs($candidate);
+
+        // candidate can view interviews index and show
+        $this->get('/interviews')->assertOk();
+        $this->get('/interviews/' . $interview->id)->assertOk();
+
+        // candidate cannot review
+        $this->get('/submissions')->assertStatus(403);
+    }
+}

--- a/tests/Feature/InterviewCrudTest.php
+++ b/tests/Feature/InterviewCrudTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+/**
+ * Feature tests for Interview CRUD operations.
+ *
+ * @category Tests
+ * @package  Feature
+ * @author   Horizon
+ * @license  MIT License
+ * @link     https://github.com/marcellopato/horizon
+ */
+class InterviewCrudTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     * Reviewer should be able to create an interview with questions.
+     *
+     * @return void
+     */
+    public function testReviewerCanCreateInterviewWithQuestions(): void
+    {
+        $user = User::factory()->create(['role' => 'reviewer']);
+
+        $payload = [
+            'title' => 'Backend Engineer',
+            'description' => 'Simple interview',
+            'time_limit' => 30,
+            'questions' => [
+                ['question' => 'Tell us about yourself', 'time_limit' => 2],
+                ['question' => 'Laravel strengths?', 'time_limit' => 3],
+            ],
+        ];
+
+        $this->actingAs($user)
+            ->post(route('interviews.store'), $payload)
+            ->assertRedirect(route('interviews.index'));
+
+        $this->assertDatabaseHas(
+            'interviews',
+            [
+                'title' => 'Backend Engineer',
+                'description' => 'Simple interview',
+            ]
+        );
+
+        $this->assertDatabaseCount('questions', 2);
+    }
+}

--- a/tests/Feature/SubmissionAndReviewTest.php
+++ b/tests/Feature/SubmissionAndReviewTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Interview;
+use App\Models\Question;
+use App\Models\Submission;
+use App\Models\SubmissionAnswer;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * Feature tests for submission upload and review flows.
+ *
+ * @category Tests
+ * @package  Feature
+ * @author   Horizon
+ * @license  MIT License
+ * @link     https://github.com/marcellopato/horizon
+ */
+class SubmissionAndReviewTest extends TestCase
+{
+    /** @return array<string,mixed> */
+    private function seedInterview(): array
+    {
+        $reviewer = User::factory()->create(['role' => 'reviewer']);
+        $candidate = User::factory()->create(['role' => 'candidate']);
+
+        $interview = Interview::create([
+            'title' => 'Fullstack',
+            'description' => 'desc',
+            'time_limit' => 30,
+            'created_by' => $reviewer->id,
+            'is_active' => true,
+        ]);
+
+        $q1 = Question::create([
+            'interview_id' => $interview->id,
+            'question' => 'Q1',
+            'order' => 1,
+            'time_limit' => 2,
+        ]);
+
+        return compact('reviewer', 'candidate', 'interview', 'q1');
+    }
+
+    public function testCandidateCanUploadVideoAnswerAndSubmit(): void
+    {
+        Storage::fake('public');
+        $data = $this->seedInterview();
+        /** @var \App\Models\User $candidate */
+        $candidate = $data['candidate'];
+        /** @var \App\Models\Interview $interview */
+        $interview = $data['interview'];
+        /** @var \App\Models\Question $q1 */
+        $q1 = $data['q1'];
+
+        // Start submission
+        $this->actingAs($candidate)
+            ->post(route('submissions.start', $interview))
+            ->assertRedirect();
+
+        $submission = Submission::where('user_id', $candidate->id)
+            ->where('interview_id', $interview->id)
+            ->firstOrFail();
+
+        // Upload video
+        $file = UploadedFile::fake()->create('answer.webm', 1024, 'video/webm');
+        $res = $this->actingAs($candidate)
+            ->postJson(route('submissions.upload-video'), [
+                'submission_id' => $submission->id,
+                'question_id' => $q1->id,
+                'video' => $file,
+                'duration' => 10,
+            ]);
+
+        $res->assertOk()->assertJsonPath('success', true);
+
+        $answer = SubmissionAnswer::where('submission_id', $submission->id)
+            ->where('question_id', $q1->id)
+            ->first();
+        $this->assertNotNull($answer);
+        $this->assertEquals('completed', $answer->status);
+        Storage::disk('public')->assertExists($answer->video_path);
+
+        // Submit submission
+        $this->actingAs($candidate)
+            ->post(route('submissions.submit', $submission))
+            ->assertRedirect(route('interviews.index'));
+
+        $submission->refresh();
+        $this->assertTrue(in_array($submission->status, ['completed', 'reviewed', 'submitted'], true));
+    }
+
+    public function testReviewerCanSaveAnswerReviewAndOverallReview(): void
+    {
+        $data = $this->seedInterview();
+        /** @var \App\Models\User $reviewer */
+        $reviewer = $data['reviewer'];
+        /** @var \App\Models\User $candidate */
+        $candidate = $data['candidate'];
+        /** @var \App\Models\Interview $interview */
+        $interview = $data['interview'];
+        /** @var \App\Models\Question $q1 */
+        $q1 = $data['q1'];
+
+        // Seed a completed submission/answer
+        $submission = Submission::create([
+            'user_id' => $candidate->id,
+            'interview_id' => $interview->id,
+            'status' => 'completed',
+        ]);
+
+        $answer = SubmissionAnswer::create([
+            'submission_id' => $submission->id,
+            'question_id' => $q1->id,
+            'video_path' => 'interviews/'.$interview->id.'/submissions/'.$submission->id.'/fake.webm',
+            'recording_duration' => 12,
+            'status' => 'completed',
+        ]);
+
+        // Save per-answer review via JSON
+        $this->actingAs($reviewer)
+            ->postJson(route('submissions.save-review'), [
+                'answer_id' => $answer->id,
+                'score' => 8,
+                'rating' => 'good',
+                'comments' => 'Solid',
+            ])
+            ->assertOk()
+            ->assertJsonPath('success', true);
+
+        $answer->refresh();
+        $this->assertEquals(8, $answer->score);
+        $this->assertEquals('good', $answer->rating);
+
+        // Save overall review via JSON
+        $this->actingAs($reviewer)
+            ->postJson(route('submissions.save-overall-review'), [
+                'submission_id' => $submission->id,
+                'overall_score' => 90,
+                'recommendation' => 'recommend',
+                'overall_comments' => 'Hire',
+            ])
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('submission.status', 'reviewed');
+
+        $submission->refresh();
+        $this->assertEquals('reviewed', $submission->status);
+        $this->assertEquals(90, $submission->overall_score);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,13 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
+/**
+ * Base TestCase for application tests.
+ */
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
+    use RefreshDatabase;
 }

--- a/tests/Unit/SubmissionAnswerModelTest.php
+++ b/tests/Unit/SubmissionAnswerModelTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\SubmissionAnswer;
+use Tests\TestCase;
+
+/**
+ * Unit tests for SubmissionAnswer helpers.
+ *
+ * @category Tests
+ * @package  Unit
+ * @author   Horizon Team <dev@horizon.local>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://github.com/marcellopato/horizon
+ */
+class SubmissionAnswerModelTest extends TestCase
+{
+    /**
+     * It should return correct MIME type based on file extension.
+     *
+     * @return void
+     */
+    public function testGetVideoMimeTypeFromExtension(): void
+    {
+        $answer = new SubmissionAnswer(['video_path' => 'videos/answer-1.mp4']);
+        $this->assertSame('video/mp4', $answer->getVideoMimeType());
+
+        $answer->video_path = 'videos/answer-2.WEBM';
+        $this->assertSame('video/webm', $answer->getVideoMimeType());
+
+        $answer->video_path = 'videos/answer-3.unknown';
+        // default fallback should be webm
+        $this->assertSame('video/webm', $answer->getVideoMimeType());
+    }
+}

--- a/tests/Unit/SubmissionModelTest.php
+++ b/tests/Unit/SubmissionModelTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Interview;
+use App\Models\Question;
+use App\Models\Submission;
+use App\Models\SubmissionAnswer;
+use App\Models\User;
+use Tests\TestCase;
+
+/**
+ * Unit tests for the Submission model helpers.
+ *
+ * @category Tests
+ * @package  Unit
+ * @author   Horizon Team <dev@horizon.local>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://github.com/marcellopato/horizon
+ */
+class SubmissionModelTest extends TestCase
+{
+    /**
+     * It should be considered completed when status is
+     * completed, submitted, or reviewed.
+     *
+     * @return void
+     */
+    public function testIsCompletedTrueForCompletedSubmittedReviewed(): void
+    {
+        $submission = new Submission(['status' => 'completed']);
+        $this->assertTrue($submission->isCompleted());
+
+        $submission->status = 'submitted';
+        $this->assertTrue($submission->isCompleted());
+
+        $submission->status = 'reviewed';
+        $this->assertTrue($submission->isCompleted());
+    }
+
+    /**
+     * It should not be considered completed for in_progress
+     * or other statuses.
+     *
+     * @return void
+     */
+    public function testIsCompletedFalseForInProgressAndOther(): void
+    {
+        $submission = new Submission(['status' => 'in_progress']);
+        $this->assertFalse($submission->isCompleted());
+
+        $submission->status = 'draft';
+        $this->assertFalse($submission->isCompleted());
+    }
+
+    /**
+     * It should calculate progress percentage based on
+     * completed answers over total questions.
+     *
+     * @return void
+     */
+    public function testGetProgressPercentageCalculatesCorrectly(): void
+    {
+        $user = User::factory()->create();
+
+        $interview = Interview::create(
+            [
+                'title' => 'Tech Interview',
+                'description' => 'Test',
+                'is_active' => true,
+                'time_limit' => 30,
+                'created_by' => $user->id,
+            ]
+        );
+
+        // Create 4 questions
+        foreach ([1, 2, 3, 4] as $order) {
+            Question::create(
+                [
+                    'interview_id' => $interview->id,
+                    'question' => 'Q' . $order,
+                    'order' => $order,
+                    'time_limit' => 60,
+                ]
+            );
+        }
+
+        $submission = Submission::create(
+            [
+                'user_id' => $user->id,
+                'interview_id' => $interview->id,
+                'status' => 'in_progress',
+            ]
+        );
+
+        // 2 completed answers out of 4 total questions -> 50%
+        $q1Id = Question::where('order', 1)
+            ->where('interview_id', $interview->id)
+            ->value('id');
+        $q2Id = Question::where('order', 2)
+            ->where('interview_id', $interview->id)
+            ->value('id');
+        $q3Id = Question::where('order', 3)
+            ->where('interview_id', $interview->id)
+            ->value('id');
+
+        SubmissionAnswer::create(
+            [
+                'submission_id' => $submission->id,
+                'question_id' => $q1Id,
+                'status' => 'completed',
+            ]
+        );
+        SubmissionAnswer::create(
+            [
+                'submission_id' => $submission->id,
+                'question_id' => $q2Id,
+                'status' => 'completed',
+            ]
+        );
+        SubmissionAnswer::create(
+            [
+                'submission_id' => $submission->id,
+                'question_id' => $q3Id,
+                'status' => 'recording',
+            ]
+        );
+        // question 4 has no answer yet
+
+        $this->assertSame(50, $submission->getProgressPercentage());
+    }
+
+    /**
+     * It should return zero when there are no questions.
+     *
+     * @return void
+     */
+    public function testGetProgressPercentageZeroWhenNoQuestions(): void
+    {
+        $user = User::factory()->create();
+        $interview = Interview::create(
+            [
+                'title' => 'Empty Interview',
+                'description' => 'No questions',
+                'is_active' => true,
+                'time_limit' => null,
+                'created_by' => $user->id,
+            ]
+        );
+
+        $submission = Submission::create(
+            [
+                'user_id' => $user->id,
+                'interview_id' => $interview->id,
+                'status' => 'in_progress',
+            ]
+        );
+
+        $this->assertSame(0, $submission->getProgressPercentage());
+    }
+}
+


### PR DESCRIPTION
This PR adds comprehensive test coverage and updates documentation:

What's included
- Unit tests
  - SubmissionModelTest: isCompleted variants and getProgressPercentage (with/without questions)
  - SubmissionAnswerModelTest: getVideoMimeType for mp4/webm/default
- Feature tests
  - AuthorizationTest: role-based access (guest redirect; candidate forbidden on manage routes; reviewer/admin access; candidate cannot access review area)
- README
  - Updated PHPUnit section with the latest full test run (38 passed, 104 assertions, 34.58s)
  - Added practical commands for running tests, test environment notes (SQLite in-memory; MySQL-guarded migrations; Storage::fake), and optional CI badge snippet

Notes
- Tests run using SQLite in-memory to speed up execution
- MySQL-specific migrations are guarded to skip in SQLite

All tests are green locally inside the container.