### PR TITLE
Enable submission downloads (ZIP and per-answer)

### DIFF
--- a/resources/views/submissions/index.blade.php
+++ b/resources/views/submissions/index.blade.php
@@ -84,11 +84,11 @@
                                                         Review
                                                     </a>
                                                     
-                                                    @if($submission->status === 'completed')
-                                                        <button class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-1 px-3 rounded text-sm" 
-                                                                onclick="downloadSubmission({{ $submission->id }})">
+                                                    @if($submission->isCompleted())
+                                                        <a href="{{ route('submissions.download', $submission) }}"
+                                                           class="bg-gray-700 hover:bg-gray-900 text-white font-bold py-1 px-3 rounded text-sm">
                                                             Download
-                                                        </button>
+                                                        </a>
                                                     @endif
                                                     
                                                     <button class="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-3 rounded text-sm" 
@@ -116,11 +116,6 @@
 </div>
 
 <script>
-function downloadSubmission(submissionId) {
-    // Implement download functionality
-    alert('Download functionality to be implemented');
-}
-
 function deleteSubmission(submissionId) {
     if (confirm('Are you sure you want to delete this submission? This action cannot be undone.')) {
         fetch(`/submissions/${submissionId}`, {

--- a/resources/views/submissions/review.blade.php
+++ b/resources/views/submissions/review.blade.php
@@ -82,6 +82,7 @@
                                             @if($answer->getVideoSize())
                                                 | Size: {{ number_format($answer->getVideoSize() / 1024 / 1024, 2) }} MB
                                             @endif
+                                            | <a href="{{ route('submission-answers.download', $answer) }}" class="text-blue-600 hover:text-blue-800 font-medium">Download video</a>
                                         </div>
                                     </div>
                                 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,13 @@ Route::middleware('auth')->group(function () {
     Route::post('submissions/save-overall-review', [SubmissionController::class, 'saveOverallReview'])
         ->name('submissions.save-overall-review')
         ->middleware('can:manage-interviews');
+    // Downloads
+    Route::get('submissions/{submission}/download', [SubmissionController::class, 'download'])
+        ->name('submissions.download')
+        ->middleware('can:manage-interviews');
+    Route::get('submission-answers/{answer}/download', [SubmissionController::class, 'downloadAnswer'])
+        ->name('submission-answers.download')
+        ->middleware('can:manage-interviews');
     Route::delete('submissions/{submission}', [SubmissionController::class, 'destroy'])
         ->name('submissions.destroy')
         ->middleware('can:manage-interviews');


### PR DESCRIPTION
This PR adds download capabilities for reviewer/admin users:

What’s included
- Download all videos of a submission as a ZIP (submissions/{submission}/download)
- Download a single answer video (submission-answers/{answer}/download)
- UI wiring: 
  - Submissions list now shows a "Download" button for completed/reviewed submissions
  - Review page includes a "Download video" link per answer
- Routes are protected by can:manage-interviews to restrict to reviewer/admin

How to test
1) As reviewer (or admin):
   - Go to Submissions and click "Download" on a completed submission → should download a ZIP file
   - Inside a submission review page, click "Download video" on an answered question → should download that file
2) As candidate: 
   - Attempt to hit the download routes should result in 403
3) As guest:
   - Attempting download routes should redirect to login

Notes
- ZIP generation currently streams files into a temporary archive and returns as download.
- Next improvements (separate PR or follow-up):
  - Better filenames inside ZIP (e.g., Q1-Question-Slug.webm)
  - Optionally switch to addFile() to reduce memory when archiving large files
  - Add feature tests explicitly for download endpoints (candidate 403, guest redirect, reviewer/admin 200)